### PR TITLE
Fix code example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ let config = InitializingServer.Configuration(initializeParamsProvider: {
     // have different expectations/requirements here
    
     return InitializeParams(processId: Int(ProcessInfo.processInfo.processIdentifier),
+                            locale: nil,
                             rootPath: nil,
                             rootURI: projectURL.absoluteString,
                             initializationOptions: nil,


### PR DESCRIPTION
There was a change in the [LanguageServerProtocol project](https://github.com/ChimeHQ/LanguageServerProtocol) which introduced the `locale` parameter for initializing the server parameters: https://github.com/ChimeHQ/LanguageServerProtocol/commit/abf80b752f5db0aa3f293b30f2ffeebc0f7decdf

This PR adds the missing parameter to the code example in the `README` so it will work again.