### PR TITLE
Update the readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Setting correct environment variables could be critical for your server. Your pr
 import LanguageClient
 import LanguageServerProtocol
 
-let executionParams = Process.ExecutionParameters(path: "/usr/bin/sourcekit-lsp")
+let executionParams = Process.ExecutionParameters(path: "/usr/bin/sourcekit-lsp", environment: ProcessInfo.processInfo.userEnvironment)
 
 let localServer = LocalProcessServer(executionParameters: executionParams)
 


### PR DESCRIPTION
The process environment variables are passed down the LSP process. If not given, the SourceKit-LSP would incorrectly assume it's running on a Linux system