### PR TITLE
Remove refactored LSPClient target

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -32,7 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ChimeHQ/LanguageServerProtocol",
       "state" : {
-        "revision" : "a355005e6c00775bb567e1d5927a4d57423474c9"
+        "branch" : "main",
+        "revision" : "9ae95d89b1a3f2c5da98adea29637c519a7e3c6c"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
 			targets: ["LanguageClient"]),
 	],
 	dependencies: [
-		.package(url: "https://github.com/ChimeHQ/LanguageServerProtocol", from: "0.11.0"),
+		.package(url: "https://github.com/ChimeHQ/LanguageServerProtocol", branch: "main"),
 		.package(url: "https://github.com/Frizlab/FSEventsWrapper", from: "2.1.0"),
 		.package(url: "https://github.com/ChimeHQ/GlobPattern", from: "0.1.1"),
 		.package(url: "https://github.com/ChimeHQ/JSONRPC", from: "0.9.0"),
@@ -31,7 +31,6 @@ let package = Package(
 				.product(name: "GlobPattern", package: "GlobPattern", condition: .when(platforms: [.macOS])),
 				"JSONRPC",
 				.product(name: "LanguageServerProtocol", package: "LanguageServerProtocol"),
-				.product(name: "LSPClient", package: "LanguageServerProtocol"),
 				.product(name: "ProcessEnv", package: "ProcessEnv", condition: .when(platforms: [.macOS])),
 				"Queue",
 				"Semaphore",

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ let channel = try DataChannel.localProcessChannel(
     terminationHandler: { print("terminated") }
 )
 
-// finally, make a server you can interact with 
+// finally, make a server you can interact with
 let server = JSONRPCServerConnection(dataChannel: channel)
 ```
 
@@ -58,7 +58,6 @@ let server = JSONRPCServerConnection(dataChannel: channel)
 ```swift
 import LanguageClient
 import LanguageServerProtocol
-import LSPClient
 import Foundation
 
 let executionParams = Process.ExecutionParameters(
@@ -84,7 +83,7 @@ let provider: InitializingServer.InitializeParamsProvider = {
                                           window: nil,
                                           general: nil,
                                           experimental: nil)
-    
+
     // pay careful attention to rootPath/rootURI/workspaceFolders, as different servers will
     // have different expectations/requirements here
     return InitializeParams(processId: Int(ProcessInfo.processInfo.processIdentifier),
@@ -101,18 +100,18 @@ let server = InitializingServer(server: localServer, initializeParamsProvider: p
 
 Task {
     let docContent = try String(contentsOf: docURL)
-    
+
     let doc = TextDocumentItem(
         uri: docURL.absoluteString,
         languageId: .swift,
         version: 1,
         text: docContent
     )
-    
+
     let docParams = DidOpenTextDocumentParams(textDocument: doc)
-    
+
     try await server.textDocumentDidOpen(params: docParams)
-    
+
     // make sure to pick a reasonable position within your test document
     let pos = Position(line: 5, character: 25)
     let completionParams = CompletionParams(
@@ -121,9 +120,9 @@ Task {
         triggerKind: .invoked,
         triggerCharacter: nil
     )
-    
+
     let completions = try await server.completion(params: completionParams)
-    
+
     print("completions: ", completions)
 }
 ```
@@ -145,7 +144,7 @@ let serverProvider: MyServer.ServerProvider = {
         parameters: executionParams,
         terminationHandler: { print("terminated") }
     )
-    
+
     return JSONRPCServerConnection(dataChannel: channel)
 }
 
@@ -166,7 +165,7 @@ let paramProvider: InitializingServer.InitializeParamsProvider = {
                                           window: nil,
                                           general: nil,
                                           experimental: nil)
-    
+
     return InitializeParams(processId: Int(ProcessInfo.processInfo.processIdentifier),
                             locale: nil,
                             rootPath: nil,

--- a/Sources/LanguageClient/InitializingServer.swift
+++ b/Sources/LanguageClient/InitializingServer.swift
@@ -5,7 +5,6 @@ import os.log
 
 import Semaphore
 import LanguageServerProtocol
-import LSPClient
 
 enum InitializingServerError: Error {
 	case noStateProvider

--- a/Sources/LanguageClient/RestartingServer.swift
+++ b/Sources/LanguageClient/RestartingServer.swift
@@ -10,7 +10,6 @@ let NSEC_PER_SEC: UInt64 = 1000000000
 
 import Semaphore
 import LanguageServerProtocol
-import LSPClient
 
 public enum RestartingServerError: Error {
 	case noProvider

--- a/Sources/LanguageClient/Server+Shutdown.swift
+++ b/Sources/LanguageClient/Server+Shutdown.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 import LanguageServerProtocol
-import LSPClient
 
 extension ServerConnection {
 	/// This function will always attempt to decode "null".

--- a/Sources/LanguageClient/StatefulServer.swift
+++ b/Sources/LanguageClient/StatefulServer.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 import LanguageServerProtocol
-import LSPClient
 
 extension ServerConnection {
 	public typealias CapabilitiesSequence = AsyncStream<ServerCapabilities>

--- a/Tests/LanguageClientTests/ServerTests.swift
+++ b/Tests/LanguageClientTests/ServerTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import LanguageServerProtocol
-import LSPClient
 import LanguageClient
 
 enum ServerTestError: Error {


### PR DESCRIPTION
NOTE: The LanguageServerProtocol dependency in Packages.swift should get proper version after new LSP repo tag is made