### PR TITLE
Return Created Process in `localProcessChannel`

### DIFF
--- a/Sources/LanguageClient/DataChannel+LocalProcess.swift
+++ b/Sources/LanguageClient/DataChannel+LocalProcess.swift
@@ -11,6 +11,14 @@ extension DataChannel {
 		parameters: Process.ExecutionParameters,
 		terminationHandler: @escaping @Sendable () -> Void
 	) throws -> DataChannel {
+		try localProcessChannel(parameters: parameters, terminationHandler: terminationHandler).channel
+	}
+
+	@available(macOS 12.0, *)
+	public static func localProcessChannel(
+		parameters: Process.ExecutionParameters,
+		terminationHandler: @escaping @Sendable () -> Void
+	) throws -> (channel: DataChannel, process: Process) {
 		let process = Process()
 
 		let stdinPipe = Pipe()
@@ -56,7 +64,7 @@ extension DataChannel {
 			try stdinPipe.fileHandleForWriting.write(contentsOf: $0)
 		}
 
-		return DataChannel(writeHandler: handler, dataSequence: stream)
+		return (DataChannel(writeHandler: handler, dataSequence: stream), process)
 	}
 }
 


### PR DESCRIPTION
It would be nice to be able to keep around a reference to the created process when starting up a server, for instance in cases one wants to forcefully shut down a stuck or out of control server process.

I've left in the old function signature as well so no API break with this change. Lmk if you'd rather return a struct instead of a tuple here.